### PR TITLE
Build updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ gradle/wrapper/gradle-wrapper.properties
 keystore.properties
 keys/xplore signed apk info .rtf
 keys/XploreKey
+.idea/kotlinc.xml
+.idea/deploymentTargetSelector.xml

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-03-22T11:18:51.982661Z">
+        <DropdownSelection timestamp="2025-07-30T13:52:07.997701Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/Users/netanelamar/.android/avd/Pixel_8_Pro_API_35.avd" />

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.0" />
+    <option name="version" value="2.0.21" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,22 +12,23 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.hilt.android)
-    id("kotlin-kapt")
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.googleServices)
     alias(libs.plugins.firebaseCrashlytics)
+    id("com.google.devtools.ksp")
+
 }
 
 android {
     namespace = "com.netanel.xplore"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.netanel.xplore"
-        minSdk = 26
-        targetSdk = 34
-        versionCode = 5
-        versionName = "1.0.4"
+        minSdk = 30
+        targetSdk = 35
+        versionCode = 6
+        versionName = "1.0.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -75,6 +76,12 @@ android {
         disable += listOf("StateFlowValueCalledInComposition", "NotificationPermission")
         checkDependencies = true
     }
+    packaging {
+        resources {
+            excludes += "/META-INF/LICENSE.md"
+            excludes += "/META-INF/NOTICE.md"
+        }
+    }
 }
 
 dependencies {
@@ -105,7 +112,7 @@ dependencies {
     // Hilt Dependency Injection
     implementation(libs.hilt.android)
     implementation(libs.androidx.databinding.compiler)
-    kapt(libs.hilt.android.compiler)
+    ksp(libs.hilt.android.compiler)
 
     // Hilt Navigation for Compose
     implementation(libs.hilt.navigation.compose)
@@ -118,7 +125,7 @@ dependencies {
 
     // Glide for image loading
     implementation(libs.glide)
-    kapt(libs.glide.compiler)
+    ksp(libs.glide.compiler)
 
     // Retrofit + OKHttp for Networking
     implementation(libs.retrofit)
@@ -128,7 +135,7 @@ dependencies {
 
     // Room Database (Newly Added)
     implementation(libs.room.runtime)
-    kapt(libs.room.compiler)
+    ksp(libs.room.compiler)
     implementation(libs.room.ktx)
 
     // Confetti

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,4 +6,6 @@ plugins {
     alias(libs.plugins.hilt.android) apply false
     alias(libs.plugins.googleServices) apply false
     alias(libs.plugins.firebaseCrashlytics) apply false
+    id("com.google.devtools.ksp") version "2.0.21-1.0.27" apply false
+
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 # Android Gradle Plugin and Kotlin
 agp = "8.7.0"
 kotlin = "2.0.0"
+kotlinAndroid = "2.0.21"
 
 # AndroidX
 coreKtx = "1.10.1"
@@ -19,7 +20,7 @@ junitVersion = "1.1.5"
 espressoCore = "3.5.1"
 
 # Dependency Injection
-hilt = "2.47"
+hilt = "2.51"
 hiltNavigationCompose = "1.2.0"
 
 # Serialization
@@ -112,7 +113,7 @@ androidx-databinding-compiler = { group = "androidx.databinding", name = "databi
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinAndroid" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }


### PR DESCRIPTION
- Updated compileSdk and targetSdk to 35
- Increased minSdk from 26 to 30
- Bumped versionCode to 6 and versionName to 1.0.5
- Replaced kapt with ksp for Hilt, Glide, and Room compilers
- Added packaging excludes for duplicate META-INF LICENSE/NOTICE files
- Switched manual ksp plugin ID to alias in plugins block
- Declared ksp plugin and kotlinAndroid version in libs.versions.toml
- Updated Hilt version to 2.51
